### PR TITLE
Creates arguments-tip.md

### DIFF
--- a/arguments-tip.md
+++ b/arguments-tip.md
@@ -1,0 +1,25 @@
+## #1(number) - Avoid modifying or passing `arguments` into other functions—it kills optimization
+> date mm/dd/yyyy by @Berkana
+
+###Background
+Within JavaScript functions, the variable name `arguments` lets you access all of the arguments passed to the function. `arguments` is an *array-like object*; `arguments` can be accessed using array notation, and it has the *length* property, but it doesn't have many of the built-in methods that arrays have such as `filter` and `map` and `forEach`. Because of this, it is a fairly common practice to convert `arguments` into an array using the following:
+```
+var args = Array.prototype.slice.call(arguments);
+```
+This calls the `slice` method from the `Array` prototype, passing it `arguments`; the `slice` method returns a shallow copy of `arguments` as a new array object. A common shorthand for this is :
+```
+var args = [].slice.call(arguments);
+```
+In this case, instead of calling `slice` from the `Array` prototype, it is simply being called from an empty array literal.
+
+###Optimization
+Unfortunately, passing `arguments` into any function call will cause the V8 JavaScript engine used in Chrome and Node to skip optimization on the function that does this, which can result it considerably slower performance. See this article on [optimization killers](https://github.com/petkaantonov/bluebird/wiki/Optimization-killers). Passing `arguments` to any other function is known as *leaking `arguments`*.
+
+Instead, if you want an array of the arguments that lets you use you need to resort to this:
+```
+var args = new Array(arguments.length);
+for(var i = 0; i < args.length; ++i) {
+  args[i] = arguments[i];
+}
+```
+Yes it is more verbose, but in production code, it is worth it for the performance optimization.

--- a/arguments-tip.md
+++ b/arguments-tip.md
@@ -13,7 +13,7 @@ var args = [].slice.call(arguments);
 In this case, instead of calling `slice` from the `Array` prototype, it is simply being called from an empty array literal.
 
 ###Optimization
-Unfortunately, passing `arguments` into any function call will cause the V8 JavaScript engine used in Chrome and Node to skip optimization on the function that does this, which can result it considerably slower performance. See this article on [optimization killers](https://github.com/petkaantonov/bluebird/wiki/Optimization-killers). Passing `arguments` to any other function is known as *leaking `arguments`*.
+Unfortunately, passing `arguments` into any function call will cause the V8 JavaScript engine used in Chrome and Node to skip optimization on the function that does this, which can result in considerably slower performance. See this article on [optimization killers](https://github.com/petkaantonov/bluebird/wiki/Optimization-killers). Passing `arguments` to any other function is known as *leaking `arguments`*.
 
 Instead, if you want an array of the arguments that lets you use you need to resort to this:
 ```


### PR DESCRIPTION
The new tip is in a file called arguments-tip.md and is formatted according to your guidelines.

The tip is about how to avoid a common optimization-killing practice when converting `arguments` into an array.
