### PR TITLE
More specific link

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ console.log(`My name is ${firstName} ${lastName}`);
 You can do Multi-line strings without `\n` and simple logic (ie 2+3) inside `${}` in Template String.
 
 You are also able to to modify the output of template strings using a function; they are called [Tagged template strings]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/template_strings) for example usages of tagged template strings.
+(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/template_strings#Tagged_template_strings) for example usages of tagged template strings.
 
 You may also want to [read](https://hacks.mozilla.org/2015/05/es6-in-depth-template-strings-2) to understand template strings more
 


### PR DESCRIPTION
Tip #9 mentions tagged template strings and links to the MDN page for template strings. I made the link point specifically to the Tagged Template Strings section on that page.
