### PR TITLE
2016-01-22-two-ways-to-empty-an-array: fix explanation for copying an…

### DIFF
--- a/_posts/en/2016-01-22-two-ways-to-empty-an-array.md
+++ b/_posts/en/2016-01-22-two-ways-to-empty-an-array.md
@@ -41,7 +41,7 @@ which means that references to the contents of the previous array are still kept
 
 * `list.length = 0` deletes everything in the array, which does hit other references.
 
-However, if you have a copy of the array (A and Copy-A), if you delete its contents using `list.length = 0`, the copy will also lose its contents.
+However, if you have a copy of the array (e.g. `list` and `listCopy`), if you delete the `list`'s contents using `list.length = 0`, the copy is not affected and therefore still contains it's original values.
 
 Think about what will output:
 


### PR DESCRIPTION
… array

When describing the effect of setting array.length = 0,
it is stated that copies of the array will also be affected
and loose their content.
This is only true for references (listNoCopy = listA),
but not for copies (listCopy = [...listA]).
