### PR TITLE
2016-02-08: Change readonly example to {writable:false}

### DIFF
--- a/_posts/en/2016-02-08-advanced-properties.md
+++ b/_posts/en/2016-02-08-advanced-properties.md
@@ -20,7 +20,7 @@ To do so, you need to use the method `defineProperty` of the `Object` prototype 
 var a = {};
 Object.defineProperty(a, 'readonly', {
   value: 15,
-  writable: true
+  writable: false
 });
 
 a.readonly = 20;


### PR DESCRIPTION
While, confusingly, the `writable` prop of `Object.defineProperty` defaults to false, setting it to true actually enables standard behavior,
in that it _allows_ writing to the property instead of disallowing it.

Source: [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty)
