### PR TITLE
Update 2016-02-14-calculate-the-max-min-value-from-an-array.md

### DIFF
--- a/_posts/en/2016-02-14-calculate-the-max-min-value-from-an-array.md
+++ b/_posts/en/2016-02-14-calculate-the-max-min-value-from-an-array.md
@@ -32,7 +32,7 @@ Another way more easier is with the new [spread operator](https://developer.mozi
 
 ```js
 var numbers = [1, 2, 3, 4];
-Math.max(numbers...) // 4
-Math.min(numbers...) // 1
+Math.max(...numbers) // 4
+Math.min(...numbers) // 1
 ```
 


### PR DESCRIPTION
## [Spread operator and array switch]
## TL;DR;

The Spread operator examples had the numbers array and the Spread operator switched.
## Username

https://github.com/nickooms/
## Extra

Math.max(...numbers) and Math.min(...numbers) do work, while Math.max(numbers...) and Math.min(numbers...) both produce a SyntaxError: missing ) after argument list
