### PR TITLE
Tone down security nature of the unapply attack prevention tip

### DIFF
--- a/_posts/en/2016-02-11-preventing-unapply-attacks.md
+++ b/_posts/en/2016-02-11-preventing-unapply-attacks.md
@@ -11,7 +11,7 @@ categories:
     - en
 ---
 
-By overriding the builtin prototypes, attackers can rewrite code to expose and change bound arguments. This can be a serious security hole that works by exploting a polyfill es5 methods.
+By overriding the builtin prototypes, external code can cause code to break by rewriting code to expose and change bound arguments. This can be an issue that seriously breaks applications that works by using polyfill es5 methods.
 
 ```js
 // example bind polyfill
@@ -54,3 +54,4 @@ By using [Object.freeze](https://developer.mozilla.org/en-US/docs/Web/JavaScript
 ```
 
 You can read more about unapply attacks [here](https://glebbahmutov.com/blog/unapply-attack/).
+Although this concept is called an 'unapply attack' due to some code being able to access closures that normally wouldn't be in scope, it is mostly wrong to consider this a security feature due to it not preventing an attacker with code execution from extending prototypes before the freezing happens and also still having the potential to read all scopes using various language features. ECMA modules would give realm based isolation which is much stronger than this solution however still doesn't fix the issues of third party scripts.


### PR DESCRIPTION
The language of this tip is very strong in suggesting that it would prevent an attacker. If an attacker has script execution rights in your code using tricks like this can make an attackers life harder but very unlikely would stop the issue.
Closures were not really designed for security as data comes back out of them and bound to prototypes and DOM etc.
Real ES6 modules would create a whole new realm which is builtins and globals isolated from the users script execution.
