### PR TITLE
modify tip to avoid throwing; closes #42

### DIFF
--- a/_posts/en/2016-01-06-writing-a-single-method-for-arrays-and-a-single-element.md
+++ b/_posts/en/2016-01-06-writing-a-single-method-for-arrays-and-a-single-element.md
@@ -17,14 +17,14 @@ You just have to concat everything into an array first. `Array.concat` will acce
 
 ```javascript
 function printUpperCase(words) {
-  var elements = [].concat(words);
+  var elements = [].concat(words || []);
   for (var i = 0; i < elements.length; i++) {
     console.log(elements[i].toUpperCase());
   }
 }
 ```
 
-`printUpperCase` is now ready to accept a single node or an array of nodes as its parameter.
+`printUpperCase` is now ready to accept a single node or an array of nodes as its parameter.  It also avoids the potential `TypeError` that would be thrown if no parameter was passed.
 
 ```javascript
 printUpperCase("cactus");


### PR DESCRIPTION
Modified tip and a bit of explanation to avoid throwing a `TypeError`.  As written, it can throw an exception if called without a parameter:

``` js
> function printUpperCase(words) {
  var elements = [].concat(words);
   for (var i = 0; i < elements.length; i++) {
     console.log(elements[i].toUpperCase());
   }
 }
> printUpperCase()
TypeError:  Cannot read property 'toUpperCase' of undefined
```

_Note that this does not avoid the exception thrown when `words` is neither a `string` nor an `Array` of `string`s._
