### PR TITLE
Improve main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 ![header](https://raw.githubusercontent.com/loverajoel/jstips/gh-pages/resources/jstips-header-blog.gif)
 
 # JS Tips [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
-> Useful JS tips
+> Useful JavaScript tips
 
 This is an awesome project about short and useful JavaScript tips that will allow you to improve your code writing. With less than 2 minutes, you will be able to read about performance, conventions, hacks, interview questions and all the items that the future of this awesome language holds for us.
 
-Frequently, no matter if it is a weekend or a holiday, a tip will be posted and tweeted.
+Tips are added frequently (read further if you want to stay in touch). 
 
 ### Can you help us enrich it?
 Sure, you can help the project in two ways, sending your tip or reviewing future tips.
 Any improvements or suggestions are more than welcome!
-[Click to see the instructions](https://github.com/loverajoel/jstips/blob/gh-pages/CONTRIBUTING.md)
+[Instructions are here](https://github.com/loverajoel/jstips/blob/gh-pages/CONTRIBUTING.md).
 
 ### Let’s keep in touch
 
@@ -26,47 +26,47 @@ There are a lot of ways to get updates, choose your own
 - [iOS App](https://goo.gl/Y9WiBc)
 - [Android App](https://goo.gl/lYorrU)
 
-> Don't forget to Star the repo, as this will help to promote the project!
+> Don't forget to Star★ the repo, as this helps promoting the project!
 
 # Tips list
 
-- 49 - [Easiest way to extract unix timestamp in JS](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-02-26-extract-unix-timestamp-easily.md)
+- 49 - [Easiest way to extract Unix timestamps](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-02-26-extract-unix-timestamp-easily.md)
 - 48 - [Reduce builtin function usage](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-02-17-reminders-about-reduce-function-usage.md)
-- 47 - [Basics : declarations](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-02-16-basics-declarations.md)
+- 47 - [Basics: Declarations](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-02-16-basics-declarations.md)
 - 46 - [Detect document ready in pure JS](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-02-15-detect-document-ready-in-pure-js.md)
 - 45 - [Calculate the Max/Min value from an array](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-02-14-calculate-the-max-min-value-from-an-array.md)
 - 44 - [Know the passing mechanism](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-02-13-know-the-passing-mechanism.md)
 - 43 - [Use destructuring in function parameters](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-02-12-use-destructuring-in-function-parameters.md)
 - 42 - [Preventing Unapply Attacks](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-02-11-preventing-unapply-attacks.md)
 - 41 - [Array average and median](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-02-10-array-average-and-median.md)
-- 40 - [Using JSON.Stringify](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-02-09-using-json-stringify.md)
-- 39 - [Advanced Javascript Properties](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-02-08-advanced-properties.md)
-- 38 - [Flattening multidimensional Arrays in JavaScript](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-02-07-flattening-multidimensional-arrays-in-javascript.md)
+- 40 - [Using JSON.stringify](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-02-09-using-json-stringify.md)
+- 39 - [Advanced Properties](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-02-08-advanced-properties.md)
+- 38 - [Flattening multidimensional Arrays](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-02-07-flattening-multidimensional-arrays-in-javascript.md)
 - 37 - [Deduplicate an Array](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-02-06-deduplicate-an-array.md)
 - 36 - [Observe DOM changes in extensions](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-02-05-observe-dom-changes.md)
 - 35 - [Assignment Operators](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-02-04-assignment-shorthands.md)
 - 34 - [Implementing asynchronous loop](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-02-03-implementing-asynchronous-loops.md)
 - 33 - [Create Range 0...N easily using one line](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-02-02-create-range-0...n-easily-using-one-line.md)
-- 32 - [Map() to the rescue: adding order to Object properties](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-02-01-map-to-the-rescue-adding-order-to-object-properties.md)
+- 32 - [`Map()` to the rescue: adding order to Object properties](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-02-01-map-to-the-rescue-adding-order-to-object-properties.md)
 - 31 - [Avoid modifying or passing `arguments` into other functions — it kills optimization](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-31-avoid-modifying-or-passing-arguments-into-other-functions%E2%80%94it-kills-optimization.md)
 - 30 - [Converting truthy/falsy values to boolean](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-30-converting-truthy-falsy-values-to-boolean.md)
 - 29 - [Speed up recursive functions with memoization](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-29-speed-up-recursive-functions-with-memoization.md)
 - 28 - [Currying vs partial application](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-28-curry-vs-partial-application.md)
 - 27 - [Short circuit evaluation in JS](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-27-short-circuit-evaluation-in-js.md)
-- 26 - [Filtering and Sorting a List of Strings](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-26-filtering-and-sorting-a-list-of-strings.md)
+- 26 - [Filtering and sorting a list of Strings](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-26-filtering-and-sorting-a-list-of-strings.md)
 - 25 - [Using immediately invoked function expression](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-25-Using-immediately-invoked-function-expression.md)
-- 24 - [Use === instead of ==](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-24-use_%3D%3D%3D_instead_of_%3D%3D.md)
+- 24 - [Use `===` instead of `==`](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-24-use_%3D%3D%3D_instead_of_%3D%3D.md)
 - 23 - [Converting to number fast way](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-23-converting-to-number-fast-way.md)
 - 22 - [Empty an Array](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-22-two-ways-to-empty-an-array.md)
 - 21 - [Shuffle an Array](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-21-shuffle-an-array.md)
 - 20 - [Return objects to enable chaining of functions](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-20-return-objects-to-enable-chaining-of-functions.md)
-- 19 - [Safe string concatenation](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-19-safe-string-concatenation.md)
+- 19 - [Safe String concatenation](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-19-safe-string-concatenation.md)
 - 18 - [Rounding the fast way](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-18-rounding-the-fast-way.md)
 - 17 - [Node.js: Run a module if it is not "required"](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-17-nodejs-run-a-module-if-it-is-not-required.md)
 - 16 - [Passing arguments to callback functions](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-16-passing-arguments-to-callback-functions.md)
-- 15 - [Even simpler way of using indexOf as a contains clause](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-15-even-simpler-way-of-using-indexof-as-a-contains-clause.md)
+- 15 - [Even simpler way of using `indexOf` as a contains clause](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-15-even-simpler-way-of-using-indexof-as-a-contains-clause.md)
 - 14 - [Fat Arrow Functions #ES6](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-14-fat-arrow-functions.md)
-- 13 - [Measure performance of a javascript block](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-13-tip-to-measure-performance-of-a-javascript-block.md)
+- 13 - [Measure performance of a code block](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-13-tip-to-measure-performance-of-a-javascript-block.md)
 - 12 - [Pseudomandatory parameters in ES6 functions #ES6](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-12-pseudomandatory-parameters-in-es6-functions.md)
 - 11 - [Hoisting](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-11-hoisting.md)
 - 10 - [Check if a property is in an Object](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-10-check-if-a-property-is-in-a-object.md)
@@ -75,10 +75,10 @@ There are a lot of ways to get updates, choose your own
 - 07 - ["use strict" and get lazy](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-07-use-strict-and-get-lazy.md)
 - 06 - [Writing a single method for arrays and a single element](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-06-writing-a-single-method-for-arrays-and-a-single-element.md)
 - 05 - [Differences between `undefined` and `null`](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-05-differences-between-undefined-and-null.md)
-- 04 - [Sorting strings with accented characters](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-04-sorting-strings-with-accented-characters.md)
+- 04 - [Sorting Strings with accented characters](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-04-sorting-strings-with-accented-characters.md)
 - 03 - [Improve Nested Conditionals](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-03-improve-nested-conditionals.md)
-- 02 - [ReactJs - Keys in children components are important](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-02-keys-in-children-components-are-important.md)
-- 01 - [AngularJs: `$digest` vs `$apply`](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-01-angularjs-digest-vs-apply.md)
+- 02 - [ReactJS - Keys in children components are important](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-02-keys-in-children-components-are-important.md)
+- 01 - [AngularJS: `$digest` vs `$apply`](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-01-angularjs-digest-vs-apply.md)
 - 00 - [Insert item inside an Array](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2015-12-29-insert-item-inside-an-array.md)
 
 ### License


### PR DESCRIPTION
I've made a couple of changes in the main README.md.

First: The under title of JS tips should explain what "JS" means.
Second: I think the "no matter if it is a weekend or a holiday" was a relic from "every day", so I've removed that and changed the wording (as we have more channels than Twitter and GitHub).

Also I've removed "JavaScript" from the titles, as our tips are obviously about JS. No need to add that to titles.
Plus I've corrected a few names.

@loverajoel I think we should add title rules. Such as code in titles have to use the code tics `.  No mentioning of the word "JavaScript" / JS. And maybe: http://grammar.yourdictionary.com/capitalization/rules-for-capitalization-in-titles.html
