### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ There are a lot of ways to get updates, choose your own
 - 30 - [Converting truthy/falsy values to boolean](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-30-converting-truthy-falsy-values-to-boolean.md)
 - 29 - [Speed up recursive functions with memoization](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-29-speed-up-recursive-functions-with-memoization.md)
 - 28 - [Currying vs partial application](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-28-curry-vs-partial-application.md)
-- 27 - [Short circuit evaluation in JS](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-27-short-circuit-evaluation-in-js.md)
+- 27 - [Short circuit evaluation](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-27-short-circuit-evaluation-in-js.md)
 - 26 - [Filtering and sorting a list of Strings](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-26-filtering-and-sorting-a-list-of-strings.md)
 - 25 - [Using immediately invoked function expression](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-25-Using-immediately-invoked-function-expression.md)
 - 24 - [Use `===` instead of `==`](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-24-use_%3D%3D%3D_instead_of_%3D%3D.md)


### PR DESCRIPTION
## Removes redundant JS mention
## TL;DR;

Redundant JS mention
## Username

@ryanoasis 
## Extra
- removes redundant mention of 'JS' (all of these are "in JS")
- makes tip description consistent with the others
- tip 46 I think is an exception to this because it helps clarify that it is not referring to the more common jQuery implementation
