### PR TITLE
Update 2016-01-31-avoid-modifying-or-passing-arguments-into-other-fun…

### DIFF
--- a/_posts/en/2016-01-31-avoid-modifying-or-passing-arguments-into-other-functions—it-kills-optimization.md
+++ b/_posts/en/2016-01-31-avoid-modifying-or-passing-arguments-into-other-functions—it-kills-optimization.md
@@ -26,6 +26,8 @@ var args = [].slice.call(arguments);
 ```
 In this case, instead of calling `slice` from the `Array` prototype, it is simply being called from an empty array literal.
 
+However, the performance of `Array.prototype.slice.call(arguments);` is better than `[].slice.call(arguments);`, here is the [JsPerf](http://jsperf.com/array-vs-array-literal-for-arguments)
+
 ###Optimization
 
 Unfortunately, passing `arguments` into any function call will cause the V8 JavaScript engine used in Chrome and Node to skip optimization on the function that does this, which can result in considerably slower performance. See this article on [optimization killers](https://github.com/petkaantonov/bluebird/wiki/Optimization-killers). Passing `arguments` to any other function is known as *leaking `arguments`*.


### PR DESCRIPTION
## Add performance compare between `Array.prototype.slice.call(arguments)` and `[].slice.call(arguments);`
## TL;DR;

Add performance compare between `Array.prototype.slice.call(arguments)` and `[].slice.call(arguments);`
## Username

[@zangw](https://github.com/richzw)
## Extra

None
