### PR TITLE
fix error tip-61: Binding objects to functions

### DIFF
--- a/_posts/en/javascript/2017-01-19-binding-objects-to-functions.md
+++ b/_posts/en/javascript/2017-01-19-binding-objects-to-functions.md
@@ -3,7 +3,7 @@ layout: post
 
 title: Binding objects to functions
 tip-number: 61
-tip-username: loverajoel 
+tip-username: loverajoel
 tip-username-profile: https://github.com/loverajoel
 tip-tldr: Understanding how to use `Bind` method with objects and functions in JavaScript
 
@@ -42,19 +42,19 @@ A copy of the given function along with the specified `this` value and initial a
 ```js
 const myCar = {
  brand: 'Ford',
- type: 'Sedan'
- Color: ‘Red’
+ type: 'Sedan',
+ color: 'Red'
 };
 
-const getBrand = () => {
+const getBrand = function () {
  console.log(this.brand);
 };
 
-const getType = () => {
+const getType = function () {
  console.log(this.type);
 };
 
-const getColor = () => {
+const getColor = function () {
  console.log(this.color);
 };
 
@@ -64,6 +64,7 @@ getBrand(myCar); // object not bind,undefined
 
 getType.bind(myCar)(); // Sedan
 
-getColor.bind(myCar); // Red
+let boundGetColor = getColor.bind(myCar);
+boundGetColor(); // Red
 
 ```

--- a/_posts/zh_CN/javascript/2017-01-19-binding-objects-to-functions.md
+++ b/_posts/zh_CN/javascript/2017-01-19-binding-objects-to-functions.md
@@ -3,7 +3,7 @@ layout: post
 
 title: 给函数 Bind 对象
 tip-number: 61
-tip-username: loverajoel 
+tip-username: loverajoel
 tip-username-profile: https://github.com/loverajoel
 tip-tldr: 理解在 JavaScript 中如何使用 `Bind` 方法绑定对象和函数
 
@@ -42,19 +42,19 @@ fun.bind(thisArg[, arg1[, arg2[, ...]]])
 ```js
 const myCar = {
  brand: 'Ford',
- type: 'Sedan'
- Color: ‘Red’
+ type: 'Sedan',
+ color: 'Red'
 };
 
-const getBrand = () => {
+const getBrand = function () {
  console.log(this.brand);
 };
 
-const getType = () => {
+const getType = function () {
  console.log(this.type);
 };
 
-const getColor = () => {
+const getColor = function () {
  console.log(this.color);
 };
 
@@ -64,6 +64,7 @@ getBrand(myCar); // object not bind,undefined
 
 getType.bind(myCar)(); // Sedan
 
-getColor.bind(myCar); // Red
+let boundGetColor = getColor.bind(myCar);
+boundGetColor(); // Red
 
 ```

--- a/_posts/zh_TW/javascript/2017-01-19-binding-objects-to-functions.md
+++ b/_posts/zh_TW/javascript/2017-01-19-binding-objects-to-functions.md
@@ -42,28 +42,29 @@ fun.bind(thisArg[, arg1[, arg2[, ...]]])
 ```js
 const myCar = {
  brand: 'Ford',
- type: 'Sedan'
- Color: ‘Red’
+ type: 'Sedan',
+ color: 'Red'
 };
 
-const getBrand = () => {
+const getBrand = function () {
  console.log(this.brand);
 };
 
-const getType = () => {
+const getType = function () {
  console.log(this.type);
 };
 
-const getColor = () => {
+const getColor = function () {
  console.log(this.color);
 };
 
-getBrand(); // 物件沒有被 bind，undefined
+getBrand(); // object not bind,undefined
 
-getBrand(myCar); // 物件沒有被 bind，undefined
+getBrand(myCar); // object not bind,undefined
 
 getType.bind(myCar)(); // Sedan
 
-getColor.bind(myCar); // Red
+let boundGetColor = getColor.bind(myCar);
+boundGetColor(); // Red
 
 ```


### PR DESCRIPTION
## fix error tip-61: Binding objects to functions

jstips was awesome! But when i read tip-61,  There are two noticeable error in the code

 + arrow function were already bound `this`.
 + Function.prototype.bind just bind `target this` for the fun, not call it. 